### PR TITLE
修复: 1.server port == 0时的处理(getport获取临时端口); 2.增加peeksize()接口用于确定待接收数据大小.

### DIFF
--- a/ffrdp/ffrdp.h
+++ b/ffrdp/ffrdp.h
@@ -1,14 +1,24 @@
 #ifndef __FFRDP_H__
 #define __FFRDP_H__
 
-void* ffrdp_init  (char *ip, int port, char *txkey, char *rxkey, int server, int smss, int sfec);
-void  ffrdp_free  (void *ctxt);
-int   ffrdp_send  (void *ctxt, char *buf, int len);
-int   ffrdp_recv  (void *ctxt, char *buf, int len);
-int   ffrdp_isdead(void *ctxt);
-void  ffrdp_update(void *ctxt);
-void  ffrdp_flush (void *ctxt);
-void  ffrdp_dump  (void *ctxt, int clearhistory);
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void* ffrdp_init     (const char *ip, int port, const char *txkey, const char *rxkey, int server, int smss, int sfec);
+int   ffrdp_getport  (void *ctxt);
+void  ffrdp_free     (void *ctxt);
+int   ffrdp_send     (void *ctxt, const char *buf, int len);
+int   ffrdp_recv     (void *ctxt, char *buf, int len);
+int   ffrdp_peeksize (void *ctxt);
+int   ffrdp_isdead   (void *ctxt);
+void  ffrdp_update   (void *ctxt);
+void  ffrdp_flush    (void *ctxt);
+void  ffrdp_dump     (void *ctxt, int clearhistory);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif
 


### PR DESCRIPTION
1.修复传入 server port == 0 时 server_addr 不正确的端口, 并增加 ffrdp_getport() 获取临时端口号.
2.增加 ffrdp_peeksize() 接口用于确定待接收数据大小, 因为很多时候并非循环 recv().